### PR TITLE
Squelch std::auto_ptr deprecated warns

### DIFF
--- a/patches/002-std-auto-ptr-deprecated-warnings.patch
+++ b/patches/002-std-auto-ptr-deprecated-warnings.patch
@@ -1,0 +1,152 @@
+commit df904965833dcf1bf2eb4d7d1416369dd806e092
+Author: Peter Dimov <pdimov@pdimov.com>
+Date:   Thu Sep 10 23:45:47 2015 +0300
+
+    Disable deprecation warnings on g++/clang
+
+diff --git a/boost/smart_ptr/detail/shared_count.hpp b/boost/smart_ptr/detail/shared_count.hpp
+index cd07ed6..7996aa4 100644
+--- a/boost/smart_ptr/detail/shared_count.hpp
++++ b/boost/smart_ptr/detail/shared_count.hpp
+@@ -28,6 +28,7 @@
+ #include <boost/smart_ptr/bad_weak_ptr.hpp>
+ #include <boost/smart_ptr/detail/sp_counted_base.hpp>
+ #include <boost/smart_ptr/detail/sp_counted_impl.hpp>
++#include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
+ #include <boost/detail/workaround.hpp>
+ // In order to avoid circular dependencies with Boost.TR1
+ // we make sure that our include of <memory> doesn't try to
+@@ -42,6 +43,11 @@
+ 
+ #include <boost/core/addressof.hpp>
+ 
++#if defined( BOOST_SP_DISABLE_DEPRECATED )
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++#endif
++
+ namespace boost
+ {
+ 
+@@ -692,6 +698,10 @@ inline shared_count::shared_count( weak_count const & r, sp_nothrow_tag ): pi_(
+ 
+ } // namespace boost
+ 
++#if defined( BOOST_SP_DISABLE_DEPRECATED )
++#pragma GCC diagnostic pop
++#endif
++
+ #ifdef __BORLANDC__
+ # pragma warn .8027     // Functions containing try are not expanded inline
+ #endif
+diff --git a/boost/smart_ptr/detail/sp_disable_deprecated.hpp b/boost/smart_ptr/detail/sp_disable_deprecated.hpp
+new file mode 100644
+index 0000000..f79bdf3
+--- /dev/null
++++ b/boost/smart_ptr/detail/sp_disable_deprecated.hpp
+@@ -0,0 +1,40 @@
++#ifndef BOOST_SMART_PTR_DETAIL_SP_DISABLE_DEPRECATED_HPP_INCLUDED
++#define BOOST_SMART_PTR_DETAIL_SP_DISABLE_DEPRECATED_HPP_INCLUDED
++
++// MS compatible compilers support #pragma once
++
++#if defined(_MSC_VER) && (_MSC_VER >= 1020)
++# pragma once
++#endif
++
++//
++//  boost/smart_ptr/detail/sp_disable_deprecated.hpp
++//
++//  Copyright 2015 Peter Dimov
++//
++//  Distributed under the Boost Software License, Version 1.0.
++//  See accompanying file LICENSE_1_0.txt or copy at
++//  http://www.boost.org/LICENSE_1_0.txt)
++//
++
++#include <boost/config.hpp>
++
++#if defined( __GNUC__ ) && ( defined( __GXX_EXPERIMENTAL_CXX0X__ ) || ( __cplusplus >= 201103L ) )
++
++# if defined( BOOST_GCC )
++
++#  if BOOST_GCC >= 40600
++#   define BOOST_SP_DISABLE_DEPRECATED
++#  endif
++
++# elif defined( __clang__ ) && defined( __has_warning )
++
++#  if __has_warning( "-Wdeprecated-declarations" )
++#   define BOOST_SP_DISABLE_DEPRECATED
++#  endif
++
++# endif
++
++#endif
++
++#endif // #ifndef BOOST_SMART_PTR_DETAIL_SP_DISABLE_DEPRECATED_HPP_INCLUDED
+diff --git a/boost/smart_ptr/scoped_ptr.hpp b/boost/smart_ptr/scoped_ptr.hpp
+index be6722d..d5d8720 100644
+--- a/boost/smart_ptr/scoped_ptr.hpp
++++ b/boost/smart_ptr/scoped_ptr.hpp
+@@ -15,12 +15,18 @@
+ #include <boost/assert.hpp>
+ #include <boost/checked_delete.hpp>
+ #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
++#include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
+ #include <boost/detail/workaround.hpp>
+ 
+ #ifndef BOOST_NO_AUTO_PTR
+ # include <memory>          // for std::auto_ptr
+ #endif
+ 
++#if defined( BOOST_SP_DISABLE_DEPRECATED )
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++#endif
++
+ namespace boost
+ {
+ 
+@@ -154,4 +160,8 @@ template<class T> inline T * get_pointer(scoped_ptr<T> const & p) BOOST_NOEXCEPT
+ 
+ } // namespace boost
+ 
++#if defined( BOOST_SP_DISABLE_DEPRECATED )
++#pragma GCC diagnostic pop
++#endif
++
+ #endif // #ifndef BOOST_SMART_PTR_SCOPED_PTR_HPP_INCLUDED
+diff --git a/boost/smart_ptr/shared_ptr.hpp b/boost/smart_ptr/shared_ptr.hpp
+index 991ca3d..47bc33d 100644
+--- a/boost/smart_ptr/shared_ptr.hpp
++++ b/boost/smart_ptr/shared_ptr.hpp
+@@ -29,6 +29,7 @@
+ #include <boost/detail/workaround.hpp>
+ #include <boost/smart_ptr/detail/sp_convertible.hpp>
+ #include <boost/smart_ptr/detail/sp_nullptr_t.hpp>
++#include <boost/smart_ptr/detail/sp_disable_deprecated.hpp>
+ 
+ #if !defined(BOOST_SP_NO_ATOMIC_ACCESS)
+ #include <boost/smart_ptr/detail/spinlock_pool.hpp>
+@@ -47,6 +48,11 @@
+ #endif
+ #endif
+ 
++#if defined( BOOST_SP_DISABLE_DEPRECATED )
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
++#endif
++
+ namespace boost
+ {
+ 
+@@ -1064,4 +1070,8 @@ template< class T > std::size_t hash_value( boost::shared_ptr<T> const & p ) BOO
+ 
+ } // namespace boost
+ 
++#if defined( BOOST_SP_DISABLE_DEPRECATED )
++#pragma GCC diagnostic pop
++#endif
++
+ #endif  // #ifndef BOOST_SMART_PTR_SHARED_PTR_HPP_INCLUDED


### PR DESCRIPTION
Take an already committed upstream patch for std::auto_ptr deprecation
warns in boost headers when using boost with gcc 5.2.1 or later. (Note
that this squelches warns when using boost, not while building boost
itself.)