### PR TITLE
Warn user if user-config.jam is detected

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -19,6 +19,12 @@ config()
 
 build()
 {
+    # Check if the user has a user-config.jam, and warn
+    if [[ -e $HOME/user-config.jam ]]; then
+        echo "WARNING: a user-config.jam file has been detectedi\n"\
+             "This can break the LSST boost build process"
+    fi
+
 	detect_compiler
 	echo "Building boost with cxxflags=$CXX_CXX11_FLAG"
 


### PR DESCRIPTION
A user-config.jam file can potentially break the lsst boot build process.
Warn the user if one is detected on their system.