### PR TITLE
DM-7109: Remove call to install_name_tool.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -76,9 +76,4 @@ install()
 	./b2 -j $NJOBS install
 
 	install_ups
-
-        if [[ $OSTYPE == darwin* && -f "$PREFIX"/lib/libboost_python.dylib ]]; then
-            install_name_tool -change libpython2.7.dylib @rpath/libpython2.7.dylib "$PREFIX"/lib/libboost_python.dylib
-        fi
-
 }


### PR DESCRIPTION
This is doubly redundant:

- Per SIM-1314, libboost_python.dylib no longer builds against
  libpython.dylib.
- We no longer support Python 2.7 anyway.